### PR TITLE
Issue #1: fix auto select model on provider change and add custom ollama endpoint support

### DIFF
--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -14,11 +14,21 @@ interface SettingsModalProps {
 
 type ProviderKey = 'openai' | 'anthropic' | 'deepseek' | 'gemini' | 'cohere' | 'mistral' | 'ollama' | 'grok';
 
-type ApiKeyState = Record<ProviderKey, string>;
+// Providers that require API keys (excludes Ollama which uses endpoint URL instead)
+type ApiKeyProviderKey = Exclude<ProviderKey, 'ollama'>;
+
+type ApiKeyState = Record<ApiKeyProviderKey, string>;
 
 type SettingsSection = 'llm-providers';
 
-const PROVIDERS: ProviderKey[] = ['openai', 'anthropic', 'deepseek', 'gemini', 'cohere', 'mistral', 'ollama', 'grok'];
+// All providers in display order (Ollama rendered differently inline)
+const ALL_PROVIDERS: ProviderKey[] = ['openai', 'anthropic', 'deepseek', 'gemini', 'cohere', 'mistral', 'ollama', 'grok'];
+
+// Providers that need API key configuration (used for state management)
+const API_KEY_PROVIDERS: ApiKeyProviderKey[] = ['openai', 'anthropic', 'deepseek', 'gemini', 'cohere', 'mistral', 'grok'];
+
+// Default Ollama endpoint
+const DEFAULT_OLLAMA_ENDPOINT = 'http://localhost:11434/v1';
 
 const PROVIDER_DISPLAY_NAMES: Record<ProviderKey, string> = {
   openai: 'OpenAI',
@@ -61,15 +71,16 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const [activeSection, setActiveSection] = useState<SettingsSection>('llm-providers');
   const [apiKeys, setApiKeys] = useState<ApiKeyState>(() => {
     const initial: Partial<ApiKeyState> = {};
-    PROVIDERS.forEach(provider => {
+    API_KEY_PROVIDERS.forEach(provider => {
       initial[provider] = '';
     });
     return initial as ApiKeyState;
   });
+  const [ollamaEndpoint, setOllamaEndpoint] = useState<string>(DEFAULT_OLLAMA_ENDPOINT);
   const [isSaving, setIsSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
-  // Load existing API keys (masked) - reload from storage to ensure fresh data
+  // Load existing API keys (masked) and Ollama endpoint - reload from storage to ensure fresh data
   useEffect(() => {
     async function loadKeys() {
       // Ensure keys are loaded from storage (handles hot reload case)
@@ -77,10 +88,13 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
 
       // Now load the masked keys into the form
       const loadedKeys: Partial<ApiKeyState> = {};
-      PROVIDERS.forEach(provider => {
+      API_KEY_PROVIDERS.forEach(provider => {
         loadedKeys[provider] = llmClient.getApiKey(provider) ? '********' : '';
       });
       setApiKeys(loadedKeys as ApiKeyState);
+
+      // Load Ollama endpoint
+      setOllamaEndpoint(llmClient.getOllamaBaseUrl() || DEFAULT_OLLAMA_ENDPOINT);
     }
 
     loadKeys();
@@ -93,7 +107,8 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
     try {
       let hasChanges = false;
 
-      for (const provider of PROVIDERS) {
+      // Save API keys for providers that need them
+      for (const provider of API_KEY_PROVIDERS) {
         const key = apiKeys[provider];
         const storageKey = STORAGE_KEYS[provider];
 
@@ -106,14 +121,23 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         }
       }
 
+      // Save Ollama endpoint if it has changed from the current value
+      const currentOllamaUrl = llmClient.getOllamaBaseUrl();
+      if (ollamaEndpoint && ollamaEndpoint !== currentOllamaUrl) {
+        await tauriDb.setSetting('ollama:endpoint', ollamaEndpoint);
+        llmClient.setOllamaBaseUrl(ollamaEndpoint);
+        console.log(`[Settings] Saved Ollama endpoint: ${ollamaEndpoint}`);
+        hasChanges = true;
+      }
+
       if (hasChanges) {
-        setSaveMessage('API keys saved successfully');
+        setSaveMessage('Settings saved successfully');
       } else {
         setSaveMessage('No changes to save');
       }
     } catch (error) {
-      console.error('[Settings] Failed to save API keys:', error);
-      setSaveMessage('Failed to save API keys');
+      console.error('[Settings] Failed to save settings:', error);
+      setSaveMessage('Failed to save settings');
     } finally {
       setIsSaving(false);
     }
@@ -168,19 +192,19 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
           </div>
 
           {/* Right content - Settings for active section */}
-          <div className="flex-1 flex flex-col min-h-0">
+          <div className="flex-1 flex flex-col min-h-0 overflow-y-auto">
             {activeSection === 'llm-providers' && (
-              <div className="p-6 flex flex-col h-full">
+              <div className="p-6 flex flex-col">
                 <div className="flex-shrink-0 mb-4">
-                  <h3 className="text-text-primary text-lg font-medium mb-1">LLM Provider API Keys</h3>
+                  <h3 className="text-text-primary text-lg font-medium mb-1">LLM Provider Configuration</h3>
                   <p className="text-text-secondary text-sm">
-                    Configure API keys for the LLM providers you want to use. Keys are stored securely and never leave your device.
+                    Configure API keys for cloud providers and endpoint URL for Ollama. Settings are stored securely and never leave your device.
                   </p>
                 </div>
 
-                {/* API Key inputs - 2 column grid */}
+                {/* Provider inputs - 2 column grid */}
                 <div className="grid grid-cols-2 gap-x-6 gap-y-4 flex-shrink-0">
-                  {PROVIDERS.map((provider) => (
+                  {ALL_PROVIDERS.map((provider) => (
                     <div key={provider}>
                       <label className="text-text-muted text-xs block mb-1.5 font-medium flex items-center gap-2">
                         <img
@@ -189,14 +213,25 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                           className="w-4 h-4 object-contain"
                         />
                         {PROVIDER_DISPLAY_NAMES[provider]}
+                        {provider === 'ollama' && <span className="text-text-muted/60">(Endpoint URL)</span>}
                       </label>
-                      <input
-                        type="password"
-                        value={apiKeys[provider]}
-                        onChange={(e) => handleKeyChange(provider, e.target.value)}
-                        placeholder={`Enter API key`}
-                        className="input w-full"
-                      />
+                      {provider === 'ollama' ? (
+                        <input
+                          type="text"
+                          value={ollamaEndpoint}
+                          onChange={(e) => setOllamaEndpoint(e.target.value)}
+                          placeholder={DEFAULT_OLLAMA_ENDPOINT}
+                          className="input w-full placeholder:text-text-muted/50"
+                        />
+                      ) : (
+                        <input
+                          type="password"
+                          value={apiKeys[provider]}
+                          onChange={(e) => handleKeyChange(provider, e.target.value)}
+                          placeholder="Enter API key"
+                          className="input w-full"
+                        />
+                      )}
                     </div>
                   ))}
                 </div>

--- a/frontend/src/llm/client.ts
+++ b/frontend/src/llm/client.ts
@@ -215,6 +215,13 @@ class LLMClient {
     return Object.keys(DEFAULT_MODELS) as LLMProviderType[];
   }
 
+  /**
+   * Get the default model for a specific provider
+   */
+  getDefaultModelForProvider(provider: LLMProviderType): string {
+    return DEFAULT_MODELS[provider] || 'mock-model';
+  }
+
   // Cache for dynamically fetched models
   private dynamicModelCache: Map<LLMProviderType, { models: ModelInfo[]; timestamp: number }> = new Map();
   private MODEL_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -1079,6 +1086,13 @@ class LLMClient {
   }
 
   /**
+   * Get the current Ollama base URL
+   */
+  getOllamaBaseUrl(): string {
+    return this.ollamaBaseUrl;
+  }
+
+  /**
    * Load API keys from Tauri SQLite storage
    * Called at app startup to initialize keys before settings panel is opened
    */
@@ -1112,6 +1126,17 @@ class LLMClient {
           // Individual key load failure - continue with others
         }
       }
+
+      // Load Ollama endpoint URL
+      try {
+        const ollamaUrl = await tauriDb.getSetting('ollama:endpoint');
+        if (ollamaUrl) {
+          this.setOllamaBaseUrl(ollamaUrl);
+          console.log(`[LLMClient] Loaded Ollama endpoint: ${ollamaUrl}`);
+        }
+      } catch {
+        // Ollama URL load failure - use default
+      }
     } catch (error) {
       console.warn('[LLMClient] Failed to load API keys from Tauri DB:', error);
       // Fallback to localStorage for non-Tauri environments
@@ -1139,6 +1164,13 @@ class LLMClient {
         this.setApiKey(provider as LLMProviderType, key);
         console.log(`[LLMClient] Loaded API key from localStorage for ${provider}`);
       }
+    }
+
+    // Load Ollama endpoint URL from localStorage
+    const ollamaUrl = localStorage.getItem('ollama:endpoint');
+    if (ollamaUrl) {
+      this.setOllamaBaseUrl(ollamaUrl);
+      console.log(`[LLMClient] Loaded Ollama endpoint from localStorage: ${ollamaUrl}`);
     }
   }
 }


### PR DESCRIPTION

### Model Selection Fix

When a user changed an agent's provider (e.g., from Anthropic to Ollama), the model field remained unchanged, causing API calls to fail with invalid model names.

Now when the provider changes:
1. Available models are fetched from the new provider's API
2. If the current model doesn't exist in the new provider's model list, it's automatically updated to the first available model

This correctly handles Ollama where we cannot assume which models are installed on the user's server.
<img width="315" height="197" alt="Screenshot 2026-01-28 at 5 40 35 PM" src="https://github.com/user-attachments/assets/02391cb6-db26-4b62-b32e-e80a7123d417" />
<img width="1094" height="159" alt="Screenshot 2026-01-28 at 5 44 21 PM" src="https://github.com/user-attachments/assets/79a082d2-927f-48c5-b058-cf2950174c8f" />

### Custom Ollama Endpoint Support

Added support for configuring a custom Ollama API endpoint URL. Users can now connect to remote Ollama servers (e.g., `https://ollama.internalnet.com/v1`) instead of only localhost. The default remains `http://localhost:11434/v1`.


